### PR TITLE
Remove superfluous spaces in PDF string

### DIFF
--- a/jlreq.cls
+++ b/jlreq.cls
@@ -4436,9 +4436,12 @@
 
 
 % デフォルト設定
-\newcommand{\contentsname}{目 次}
+\AtBeginDocument{%
+  \providecommand*{\texorpdfstring}[2]{#1}
+}
+\newcommand{\contentsname}{\texorpdfstring{目 次}{目次}}
 \newcommand{\refname}{参考文献}
-\newcommand{\indexname}{索 引}
+\newcommand{\indexname}{\texorpdfstring{索 引}{索引}}
 \pagestyle{plain}
 \pagenumbering{arabic}
 \if@twocolumn


### PR DESCRIPTION
後方互換性を壊さない範囲で #13 を修正しました．文書クラスが既定で読み込まないパッケージへの対応を含みますし，変更しない場合は適当に close してください．

Fix #13.