### PR TITLE
章ラベルを数式ラベルに含める

### DIFF
--- a/jlreq.cls
+++ b/jlreq.cls
@@ -4527,8 +4527,9 @@
 \setlength\fboxsep{.3\zw}
 \setlength\fboxrule{\jlreq@omotekeiwidth} % 根拠はない
 % 後で
-\renewcommand{\theequation}{\@arabic\c@equation}
-\ifthenelse{\equal{\jlreq@article@type}{article}}{}{%
+\ifthenelse{\equal{\jlreq@article@type}{article}}{%
+  \renewcommand{\theequation}{\@arabic\c@equation}
+}{%
   \@addtoreset{equation}{chapter}
   \renewcommand{\theequation}{%
     \ifnum\c@chapter>\z@\thechapter.\fi \@arabic\c@equation}

--- a/jlreq.cls
+++ b/jlreq.cls
@@ -4528,6 +4528,11 @@
 \setlength\fboxrule{\jlreq@omotekeiwidth} % 根拠はない
 % 後で
 \renewcommand{\theequation}{\@arabic\c@equation}
+\ifthenelse{\equal{\jlreq@article@type}{article}}{}{%
+  \@addtoreset{equation}{chapter}
+  \renewcommand{\theequation}{%
+    \ifnum\c@chapter>\z@\thechapter.\fi \@arabic\c@equation}
+}
 
 %. 目次
 \setcounter{tocdepth}{3}


### PR DESCRIPTION
JLReq中でとくに言及も見当たらなかったので，jclassesやjsclassesのbook/report系文書クラスに倣って`\chapter`が定義されている場合は章ラベルを数式ラベルに含めるようにしてみました．