### PR TITLE
Fix `column_gap` class option

### DIFF
--- a/jlreq.cls
+++ b/jlreq.cls
@@ -552,7 +552,7 @@
 %.. 段間
 \newcommand*{\jlreq@option@column@gap}{2zw}
 \jlreq@aftercls@addtodeletecs{\jlreq@option@column@gap}
-\DeclareOptionX{column_gap}{\renewcommand*{\jlreq@option@column@gap{#1}}}
+\DeclareOptionX{column_gap}{\renewcommand*{\jlreq@option@column@gap}{#1}}
 
 %.. 行送り，指定無しの場合は文字サイズの1.7倍とする．（1.5から2倍が好ましい：2.4.2.d 注3）
 \newcommand*{\jlreq@option@baselineskip}{17zw/10}


### PR DESCRIPTION
クラスオプション `column_gap` がうまく動かなかったようなので、
パッチを作ってみました。

現在の master ブランチにある jlreq.cls を使って下記ソースをコンパイルすると、

```tex
\documentclass[twocolumn,column_gap=3zw]{jlreq}

\begin{document}

□□□□□□□□□■□□□□□□□□□■□□□□□□□□□■
□□□□□□□□□■□□□□□□□□□■□□□□□□□□□■
□□□□□□□□□■□□□□□□□□□■□□□□□□□□□■

□□□□□□□□□■□□□□□□□□□■□□□□□□□□□■
□□□□□□□□□■□□□□□□□□□■□□□□□□□□□■
□□□□□□□□□■□□□□□□□□□■□□□□□□□□□■

\end{document}
```

下記のエラーが出ます。

```
! LaTeX Error: \jlreq@option@column@gap {3zw}undefined.

See the LaTeX manual or LaTeX Companion for explanation.
Type  H <return>  for immediate help.
 ...

l.620 \ProcessOptionsX\relax
```

jlreq.cls にこのプルリクエストのパッチを当てればエラーが出なくなります。