### PR TITLE
 README-ja.md のアップデート

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -295,7 +295,7 @@ pLaTeX / upLaTeX / LuaLaTeX上で動きます．以下のパッケージを内�
 * `indent=<寸法>` 見出し文字列全体の字下げ量を指定します．
 * `after_label_space=<寸法>`：ラベル後，見出し文字列までの空きを指定します．
 * `label_format=<コード>`：ラベルのフォーマットを指定します．`label_format={\theparagraph}`などのようにします．
-* `number=[true/false]'：採番を行うかを指定します．`\NewTobiraHeading`と同様の注意が必要です．
+* `number=[true/false]`：採番を行うかを指定します．`\NewTobiraHeading`と同様の注意が必要です．
 
 ### 窓見出し
 `\NewCutinHeading`で作成します．`\<命令名>{見出し文字列}`という書式の命令を作成します．設定は以下の通り．

--- a/README-ja.md
+++ b/README-ja.md
@@ -295,6 +295,7 @@ pLaTeX / upLaTeX / LuaLaTeX上で動きます．以下のパッケージを内�
 * `indent=<寸法>` 見出し文字列全体の字下げ量を指定します．
 * `after_label_space=<寸法>`：ラベル後，見出し文字列までの空きを指定します．
 * `label_format=<コード>`：ラベルのフォーマットを指定します．`label_format={\theparagraph}`などのようにします．
+* `after_space=<寸法>`：見出しと本文との間の空きを指定します．
 * `number=[true/false]`：採番を行うかを指定します．`\NewTobiraHeading`と同様の注意が必要です．
 
 ### 窓見出し


### PR DESCRIPTION
[同行見出しの `after_space`](https://github.com/abenori/jlreq/blob/4ed396b9585a73fc9d8af5e14ee54d4274b2c404/jlreq.cls#L2805) の説明を追加しました (窓見出しと同じ)。

合わせて一箇所 Markdown の typo を修正しました。
