### PR TITLE
h ->tbp : figure and table float placement settings

### DIFF
--- a/jlreq.cls
+++ b/jlreq.cls
@@ -5447,7 +5447,7 @@
     \renewcommand{\thefigure}{\ifnum\c@chapter>\z@\thechapter.\fi \@arabic\c@figure}
   }
 }
-\newcommand*{\fps@figure}{h}
+\newcommand*{\fps@figure}{tbp}
 \newcommand*{\ftype@figure}{1}
 \newcommand*{\ext@figure}{lof}
 \newcommand*{\fnum@figure}{\figurename\thefigure}
@@ -5471,7 +5471,7 @@
     \renewcommand{\thetable}{\ifnum\c@chapter>\z@\thechapter.\fi \@arabic\c@table}
   }
 }
-\newcommand*{\fps@table}{h}
+\newcommand*{\fps@table}{tbp}
 \newcommand*{\ftype@table}{2}
 \newcommand*{\ext@table}{lot}
 \newcommand*{\fnum@table}{\tablename\thetable}


### PR DESCRIPTION
日本語組版処理の要件に合わせて従来の日本語クラスと同じ tbp 指定にしてみました。挙動がこれまでと変わるので影響が大きいかもしれませんが、既存の日本語文章クラスの挙動と合いますし、要件にも "The illustrations are usually set at the head or the foot of the page (see Figure 15)." とあるので変更してはいかがかと思いました。
https://www.w3.org/TR/jlreq/#kihonhanmen_and_examples_of_real_page_format