### PR TITLE
Fix #149

### DIFF
--- a/jlreq.cls
+++ b/jlreq.cls
@@ -2716,7 +2716,7 @@
     \edef\jlreq@do{%
       \unexpanded{%
         \clist_map_inline:Nn \jlreq@BlockHeading@spaces@headingslist {
-          \expandafter\let\csname jlreq@BlockHeading@spaces@setlist@####1\endcsname=\@undefined
+          \expandafter\let\csname jlreq@BlockHeading@spaces@setlist@##1\endcsname=\@undefined
         }%
       }%
       \unexpanded{\def\jlreq@BlockHeading@spaces@headingslist}{\exp_not:o {\jlreq@tempa}}%


### PR DESCRIPTION
`\SetBlockHeadingSpaces` のクリア処理で、`\clist_map_inline:Nn` に渡すインラインコードの `#` のエスケープが1段多く、以前の設定の削除が機能していませんでした。`####1` を `##1` に修正します。